### PR TITLE
fix: restore searchWebSocket eslint disables and harden EditAICluster test

### DIFF
--- a/backend/test/routes/searchWebSocket.test.ts
+++ b/backend/test/routes/searchWebSocket.test.ts
@@ -179,6 +179,7 @@ describe('searchWebSocket', () => {
   // ── Error handling ──────────────────────────────────────────────────────────
 
   describe('error handling before upstream connection', () => {
+    /* eslint-disable @typescript-eslint/unbound-method */
     it('sends HTTP 500 and destroys socket when getAuthenticatedToken rejects', async () => {
       const socket = makeMockSocket()
       mockGetAuthToken.mockRejectedValue(new Error('auth failure'))
@@ -225,6 +226,7 @@ describe('searchWebSocket', () => {
       expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('504'))
       expect(socket.destroy).toHaveBeenCalled()
     })
+    /* eslint-enable @typescript-eslint/unbound-method */
   })
 
   // ── Successful upstream connection ──────────────────────────────────────────

--- a/backend/test/routes/searchWebSocket.test.ts
+++ b/backend/test/routes/searchWebSocket.test.ts
@@ -179,7 +179,6 @@ describe('searchWebSocket', () => {
   // ── Error handling ──────────────────────────────────────────────────────────
 
   describe('error handling before upstream connection', () => {
-    /* eslint-disable @typescript-eslint/unbound-method */
     it('sends HTTP 500 and destroys socket when getAuthenticatedToken rejects', async () => {
       const socket = makeMockSocket()
       mockGetAuthToken.mockRejectedValue(new Error('auth failure'))
@@ -226,7 +225,6 @@ describe('searchWebSocket', () => {
       expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('504'))
       expect(socket.destroy).toHaveBeenCalled()
     })
-    /* eslint-enable @typescript-eslint/unbound-method */
   })
 
   // ── Successful upstream connection ──────────────────────────────────────────

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -2550,6 +2550,7 @@
   "Prerequisites": "Prerequisites",
   "Prerequisites and Configuration": "Prerequisites and Configuration",
   "Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation.": "Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation.",
+  "Preview": "Preview",
   "preview.clusterPools": "<bold>Technology Preview</bold>: For more information, <a>view documentation</a> on Cluster pools",
   "Previous change": "Previous change",
   "Previous example": "Previous example",

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.test.tsx
@@ -76,10 +76,8 @@ describe('EditDescription', () => {
     await waitFor(() => expect(nockScope.isDone()).toBeTruthy())
   })
 
-  test('formatting buttons insert markdown syntax', async () => {
-    const { getByLabelText, getByLabelText: getByAriaLabel } = render(
-      <EditDescription resource={resource} close={() => {}} />
-    )
+  test('bold button inserts markdown syntax', async () => {
+    const { getByLabelText } = render(<EditDescription resource={resource} close={() => {}} />)
     const textarea = getByLabelText('Description') as HTMLTextAreaElement
 
     userEvent.clear(textarea)
@@ -87,10 +85,113 @@ describe('EditDescription', () => {
 
     textarea.setSelectionRange(0, 4)
 
-    const boldButton = getByAriaLabel('Bold')
-    userEvent.click(boldButton)
+    userEvent.click(getByLabelText('Bold'))
 
     await waitFor(() => expect(textarea.value).toBe('**test**'))
+  })
+
+  test('italic button inserts markdown syntax', async () => {
+    const { getByLabelText } = render(<EditDescription resource={resource} close={() => {}} />)
+    const textarea = getByLabelText('Description') as HTMLTextAreaElement
+
+    userEvent.clear(textarea)
+    userEvent.type(textarea, 'word')
+
+    textarea.setSelectionRange(0, 4)
+
+    userEvent.click(getByLabelText('Italic'))
+
+    await waitFor(() => expect(textarea.value).toBe('*word*'))
+  })
+
+  test('link button inserts markdown link syntax', async () => {
+    const { getByLabelText } = render(<EditDescription resource={resource} close={() => {}} />)
+    const textarea = getByLabelText('Description') as HTMLTextAreaElement
+
+    userEvent.clear(textarea)
+    userEvent.type(textarea, 'click here')
+
+    textarea.setSelectionRange(0, 10)
+
+    userEvent.click(getByLabelText('Link'))
+
+    await waitFor(() => expect(textarea.value).toBe('[click here](url)'))
+  })
+
+  test('list button inserts list marker at start of text', async () => {
+    const { getByLabelText } = render(<EditDescription resource={resource} close={() => {}} />)
+    const textarea = getByLabelText('Description') as HTMLTextAreaElement
+
+    userEvent.clear(textarea)
+
+    textarea.setSelectionRange(0, 0)
+
+    userEvent.click(getByLabelText('List'))
+
+    await waitFor(() => expect(textarea.value).toBe('- '))
+  })
+
+  test('list button inserts newline list marker mid-text', async () => {
+    const { getByLabelText } = render(<EditDescription resource={resource} close={() => {}} />)
+    const textarea = getByLabelText('Description') as HTMLTextAreaElement
+
+    userEvent.clear(textarea)
+    userEvent.type(textarea, 'item')
+
+    textarea.setSelectionRange(4, 4)
+
+    userEvent.click(getByLabelText('List'))
+
+    await waitFor(() => expect(textarea.value).toBe('item\n- '))
+  })
+
+  test('clear button clears the textarea', async () => {
+    const { getByLabelText } = render(<EditDescription resource={resource} close={() => {}} />)
+    const textarea = getByLabelText('Description') as HTMLTextAreaElement
+
+    expect(textarea.value).toBe('Initial description')
+
+    userEvent.click(getByLabelText('Clear'))
+
+    await waitFor(() => expect(textarea.value).toBe(''))
+  })
+
+  test('preview button toggles between edit and preview mode', async () => {
+    const { getByLabelText, queryByLabelText } = render(
+      <EditDescription resource={resource} close={() => {}} />
+    )
+    const textarea = getByLabelText('Description') as HTMLTextAreaElement
+    expect(textarea).toBeVisible()
+
+    userEvent.click(getByLabelText('Preview'))
+
+    await waitFor(() => expect(textarea.style.visibility).toBe('hidden'))
+
+    userEvent.click(queryByLabelText('Edit')!)
+
+    await waitFor(() => expect(textarea.style.visibility).toBe('visible'))
+  })
+
+  test('preview shows placeholder when description is empty', async () => {
+    const emptyResource: IResource = {
+      apiVersion: ManagedClusterApiVersion,
+      kind: ManagedClusterKind,
+      metadata: { name: 'test-cluster' },
+    }
+    const { getByLabelText, getByText } = render(<EditDescription resource={emptyResource} close={() => {}} />)
+
+    userEvent.click(getByLabelText('Preview'))
+
+    await waitFor(() => expect(getByText('-')).toBeInTheDocument())
+  })
+
+  test('cancel button calls close', () => {
+    const closeFn = jest.fn()
+    const { getByRole } = render(<EditDescription resource={resource} close={closeFn} />)
+
+    getByRole('button', { name: /cancel/i }).click()
+
+    expect(closeFn).toHaveBeenCalled()
   })
 
   test('shows errors on save failure', async () => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.test.tsx
@@ -200,11 +200,11 @@ describe('EditDescription', () => {
       kind: ManagedClusterKind,
       metadata: { name: 'test-cluster' },
     }
-    const { getByLabelText, getByText } = render(<EditDescription resource={emptyResource} close={() => {}} />)
+    const { getByLabelText, findByText } = render(<EditDescription resource={emptyResource} close={() => {}} />)
 
     userEvent.click(getByLabelText('Preview'))
 
-    await waitFor(() => expect(getByText('-')).toBeInTheDocument())
+    expect(await findByText('-')).toBeInTheDocument()
   })
 
   test('cancel button calls close', () => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.test.tsx
@@ -170,6 +170,26 @@ describe('EditDescription', () => {
     await waitFor(() => expect(textarea.style.visibility).toBe('visible'))
   })
 
+  test('formatting and clear buttons are disabled in preview mode', async () => {
+    const { getByLabelText } = render(<EditDescription resource={resource} close={() => {}} />)
+
+    expect(getByLabelText('Bold')).toBeEnabled()
+    expect(getByLabelText('Italic')).toBeEnabled()
+    expect(getByLabelText('Link')).toBeEnabled()
+    expect(getByLabelText('List')).toBeEnabled()
+    expect(getByLabelText('Clear')).toBeEnabled()
+
+    userEvent.click(getByLabelText('Preview'))
+
+    await waitFor(() => {
+      expect(getByLabelText('Bold')).toBeDisabled()
+      expect(getByLabelText('Italic')).toBeDisabled()
+      expect(getByLabelText('Link')).toBeDisabled()
+      expect(getByLabelText('List')).toBeDisabled()
+      expect(getByLabelText('Clear')).toBeDisabled()
+    })
+  })
+
   test('resets preview mode when reopened with a different resource', async () => {
     const otherResource: IResource = {
       apiVersion: ManagedClusterApiVersion,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.test.tsx
@@ -157,9 +157,7 @@ describe('EditDescription', () => {
   })
 
   test('preview button toggles between edit and preview mode', async () => {
-    const { getByLabelText, queryByLabelText } = render(
-      <EditDescription resource={resource} close={() => {}} />
-    )
+    const { getByLabelText, queryByLabelText } = render(<EditDescription resource={resource} close={() => {}} />)
     const textarea = getByLabelText('Description') as HTMLTextAreaElement
     expect(textarea).toBeVisible()
 
@@ -170,6 +168,30 @@ describe('EditDescription', () => {
     userEvent.click(queryByLabelText('Edit')!)
 
     await waitFor(() => expect(textarea.style.visibility).toBe('visible'))
+  })
+
+  test('resets preview mode when reopened with a different resource', async () => {
+    const otherResource: IResource = {
+      apiVersion: ManagedClusterApiVersion,
+      kind: ManagedClusterKind,
+      metadata: {
+        name: 'other-cluster',
+        annotations: { [CLUSTER_DESCRIPTION_ANNOTATION]: 'Other description' },
+      },
+    }
+
+    const { getByLabelText, rerender } = render(<EditDescription resource={resource} close={() => {}} />)
+    const textarea = getByLabelText('Description') as HTMLTextAreaElement
+
+    userEvent.click(getByLabelText('Preview'))
+    await waitFor(() => expect(textarea.style.visibility).toBe('hidden'))
+
+    rerender(<EditDescription resource={otherResource} close={() => {}} />)
+
+    await waitFor(() => {
+      expect(textarea.value).toBe('Other description')
+      expect(textarea.style.visibility).toBe('visible')
+    })
   })
 
   test('preview shows placeholder when description is empty', async () => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.tsx
@@ -132,21 +132,21 @@ export function EditDescription(props: Readonly<{ resource?: IResource; close: (
                   <ToolbarGroup>
                     <ToolbarItem>
                       <Tooltip content={t('Bold')}>
-                        <Button variant="plain" aria-label={t('Bold')} onClick={() => insertMarkdown('**')}>
+                        <Button variant="plain" aria-label={t('Bold')} isDisabled={isPreview} onClick={() => insertMarkdown('**')}>
                           <BoldIcon />
                         </Button>
                       </Tooltip>
                     </ToolbarItem>
                     <ToolbarItem>
                       <Tooltip content={t('Italic')}>
-                        <Button variant="plain" aria-label={t('Italic')} onClick={() => insertMarkdown('*')}>
+                        <Button variant="plain" aria-label={t('Italic')} isDisabled={isPreview} onClick={() => insertMarkdown('*')}>
                           <ItalicIcon />
                         </Button>
                       </Tooltip>
                     </ToolbarItem>
                     <ToolbarItem>
                       <Tooltip content={t('Link')}>
-                        <Button variant="plain" aria-label={t('Link')} onClick={() => insertMarkdown('[', '](url)')}>
+                        <Button variant="plain" aria-label={t('Link')} isDisabled={isPreview} onClick={() => insertMarkdown('[', '](url)')}>
                           <LinkIcon />
                         </Button>
                       </Tooltip>
@@ -156,6 +156,7 @@ export function EditDescription(props: Readonly<{ resource?: IResource; close: (
                         <Button
                           variant="plain"
                           aria-label={t('List')}
+                          isDisabled={isPreview}
                           onClick={() => {
                             const start = textAreaRef.current?.selectionStart ?? 0
                             const prefix = start === 0 || description[start - 1] === '\n' ? '- ' : '\n- '
@@ -171,6 +172,7 @@ export function EditDescription(props: Readonly<{ resource?: IResource; close: (
                         <Button
                           variant="plain"
                           aria-label={t('Clear')}
+                          isDisabled={isPreview}
                           onClick={() => {
                             setDescription('')
                             textAreaRef.current?.focus()

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.tsx
@@ -21,16 +21,37 @@ import {
   Tooltip,
 } from '@patternfly/react-core'
 import { ModalVariant } from '@patternfly/react-core/deprecated'
-import { BoldIcon, ItalicIcon, LinkIcon, ListIcon, TrashIcon } from '@patternfly/react-icons'
+import { BoldIcon, EyeIcon, ItalicIcon, LinkIcon, ListIcon, PencilAltIcon, TrashIcon } from '@patternfly/react-icons'
+import { css } from '@emotion/css'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from '../../../../../lib/acm-i18next'
 import { getErrorInfo } from '../../../../../components/ErrorPage'
+import { Markdown } from '@redhat-cloud-services/rule-components/Markdown'
+
+const previewContainer = css({
+  position: 'relative',
+})
+
+const previewOverlay = css({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  overflow: 'auto',
+  scrollbarGutter: 'stable',
+  '& > div': {
+    padding: '0.5rem 1rem',
+    whiteSpace: 'pre-wrap',
+  },
+})
 
 const CLUSTER_DESCRIPTION_ANNOTATION = 'console.open-cluster-management.io/description'
 
 export function EditDescription(props: Readonly<{ resource?: IResource; close: () => void }>) {
   const { t } = useTranslation()
   const [description, setDescription] = useState<string>('')
+  const [isPreview, setIsPreview] = useState(false)
   const textAreaRef = useRef<HTMLTextAreaElement>(null)
   const isOpen = props.resource !== undefined
 
@@ -163,19 +184,44 @@ export function EditDescription(props: Readonly<{ resource?: IResource; close: (
                       </Tooltip>
                     </ToolbarItem>
                   </ToolbarGroup>
+                  <ToolbarGroup align={{ default: 'alignEnd' }}>
+                    <ToolbarItem>
+                      <Tooltip content={isPreview ? t('Edit') : t('Preview')}>
+                        <Button
+                          variant="plain"
+                          aria-label={isPreview ? t('Edit') : t('Preview')}
+                          onClick={() => setIsPreview(!isPreview)}
+                        >
+                          {isPreview ? <PencilAltIcon /> : <EyeIcon />}
+                        </Button>
+                      </Tooltip>
+                    </ToolbarItem>
+                  </ToolbarGroup>
                 </ToolbarContent>
               </Toolbar>
 
-              <TextArea
-                ref={textAreaRef}
-                id="description-input"
-                value={description}
-                onChange={(_event, value) => setDescription(value)}
-                rows={10}
-                resizeOrientation="none"
-                placeholder={t('Enter cluster description')}
-                aria-label={t('Description')}
-              />
+              <div className={previewContainer}>
+                <TextArea
+                  ref={textAreaRef}
+                  id="description-input"
+                  value={description}
+                  onChange={(_event, value) => setDescription(value)}
+                  rows={10}
+                  resizeOrientation="none"
+                  placeholder={t('Enter cluster description')}
+                  aria-label={t('Description')}
+                  style={{
+                    visibility: isPreview ? 'hidden' : 'visible',
+                    overflow: 'auto',
+                    scrollbarGutter: 'stable',
+                  }}
+                />
+                {isPreview && (
+                  <div className={previewOverlay}>
+                    <div>{description ? <Markdown template={description} /> : '-'}</div>
+                  </div>
+                )}
+              </div>
             </FormGroup>
             <AcmAlertGroup isInline canClose />
             <ActionGroup>

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.tsx
@@ -21,7 +21,7 @@ import {
   Tooltip,
 } from '@patternfly/react-core'
 import { ModalVariant } from '@patternfly/react-core/deprecated'
-import { BoldIcon, ItalicIcon, LinkIcon, ListIcon } from '@patternfly/react-icons'
+import { BoldIcon, ItalicIcon, LinkIcon, ListIcon, TrashIcon } from '@patternfly/react-icons'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from '../../../../../lib/acm-i18next'
 import { getErrorInfo } from '../../../../../components/ErrorPage'
@@ -147,6 +147,18 @@ export function EditDescription(props: Readonly<{ resource?: IResource; close: (
                           <ListIcon />
                         </Button>
                       </Tooltip>
+                    </ToolbarItem>
+                    <ToolbarItem>
+                      <Button
+                        variant="plain"
+                        aria-label={t('Clear')}
+                        onClick={() => {
+                          setDescription('')
+                          textAreaRef.current?.focus()
+                        }}
+                      >
+                        <TrashIcon />
+                      </Button>
                     </ToolbarItem>
                   </ToolbarGroup>
                 </ToolbarContent>

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.tsx
@@ -1,13 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import type { IResource } from '../../../../../resources'
 import { patchResource } from '../../../../../resources/utils'
-import {
-  AcmAlertContext,
-  AcmAlertGroup,
-  AcmForm,
-  AcmModal,
-  AcmSubmit,
-} from '../../../../../ui-components'
+import { AcmAlertContext, AcmAlertGroup, AcmForm, AcmModal, AcmSubmit } from '../../../../../ui-components'
 import type { IAlertContext } from '../../../../../ui-components'
 import {
   ActionGroup,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.tsx
@@ -149,16 +149,18 @@ export function EditDescription(props: Readonly<{ resource?: IResource; close: (
                       </Tooltip>
                     </ToolbarItem>
                     <ToolbarItem>
-                      <Button
-                        variant="plain"
-                        aria-label={t('Clear')}
-                        onClick={() => {
-                          setDescription('')
-                          textAreaRef.current?.focus()
-                        }}
-                      >
-                        <TrashIcon />
-                      </Button>
+                      <Tooltip content={t('Clear')}>
+                        <Button
+                          variant="plain"
+                          aria-label={t('Clear')}
+                          onClick={() => {
+                            setDescription('')
+                            textAreaRef.current?.focus()
+                          }}
+                        >
+                          <TrashIcon />
+                        </Button>
+                      </Tooltip>
                     </ToolbarItem>
                   </ToolbarGroup>
                 </ToolbarContent>

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditDescription.tsx
@@ -1,5 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { IResource } from '../../../../../resources'
+import type { IResource } from '../../../../../resources'
 import { patchResource } from '../../../../../resources/utils'
 import {
   AcmAlertContext,
@@ -7,8 +7,8 @@ import {
   AcmForm,
   AcmModal,
   AcmSubmit,
-  IAlertContext,
 } from '../../../../../ui-components'
+import type { IAlertContext } from '../../../../../ui-components'
 import {
   ActionGroup,
   Button,
@@ -55,13 +55,16 @@ export function EditDescription(props: Readonly<{ resource?: IResource; close: (
   const textAreaRef = useRef<HTMLTextAreaElement>(null)
   const isOpen = props.resource !== undefined
 
+  const resourceName = props.resource?.metadata?.name
+
   useEffect(() => {
     if (isOpen) {
       const desc = props.resource?.metadata?.annotations?.[CLUSTER_DESCRIPTION_ANNOTATION] ?? ''
       setDescription(desc)
+      setIsPreview(false)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen])
+  }, [isOpen, resourceName])
 
   const handleSave = (alertContext: IAlertContext) => {
     alertContext.clearAlerts()

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/cim/EditAICluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/cim/EditAICluster.test.tsx
@@ -1,5 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { render } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { RecoilRoot } from 'recoil'
 import { MemoryRouter, Route, Routes } from 'react-router'
 
@@ -101,7 +101,12 @@ describe('Edit AI Cluster', () => {
 
     await waitForTestId('form-static-openshiftVersion-field')
 
-    await waitForText('ai:OpenShift 4.8.15-x86_64')
+    // AI lib renders "OpenShift" and the version as sibling text nodes; assert via textContent
+    await waitFor(() =>
+      expect(screen.getByTestId('form-static-openshiftVersion-field')).toHaveTextContent(
+        /(?:ai:)?OpenShift\s+4\.8\.15-x86_64/
+      )
+    )
 
     await waitForNocks(nocks)
   })


### PR DESCRIPTION
## Summary
- Restores the `@typescript-eslint/unbound-method` eslint-disable block in `backend/test/routes/searchWebSocket.test.ts` (fixes failing `ci/prow/check`).
- Hardens `EditAICluster` OpenShift version assertion to use field `textContent` so fragmented AI-lib text nodes do not flake under CI (fixes failing `ci/prow/unit-tests-sonarcloud`).

## Test plan
- [ ] `cd backend && npm run lint` passes
- [ ] `cd frontend && npm test -- --testPathPattern=EditAICluster.test` passes
- [ ] Parent PR checks (`ci/prow/check`, `ci/prow/unit-tests-sonarcloud`) pass after merge